### PR TITLE
do not set end_of_line

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,6 @@ root = true
 [*]
 charset = utf-8
 
-end_of_line = LF
 insert_final_newline = true
 trim_trailing_whitespace = true
 


### PR DESCRIPTION
.editorconfig: removed end_of_line in the hope PyCharm will work better in Windows.

please, check if after adding this file to your repo, restarting PyCharm and reformat a file will preserve newline characters in between docstrings.