### PR TITLE
Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: all clean run
+
+VENV := venv
+MAIN := main.py
+
+PIP := $(VENV)/bin/pip
+PYTHON := $(VENV)/bin/python
+
+all run: $(VENV) $(MAIN)
+	$(PYTHON) $(MAIN)
+
+clean:
+	@ rm -rf $(VENV)
+
+$(VENV): requirements.txt
+	virtualenv -p python2 $(VENV)
+	$(PIP) install -r $<
+	ln -s /usr/lib/python2.7/dist-packages/PyQt4 $(VENV)/lib/python2.7/site-packages/
+	ln -s /usr/lib/python2.7/dist-packages/sip.*so $(VENV)/lib/python2.7/site-packages/

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,5 @@ clean:
 	@ rm -rf $(VENV)
 
 $(VENV): requirements.txt
-	virtualenv -p python2 $(VENV)
+	virtualenv --system-site-packages -p python2 $(VENV)
 	$(PIP) install -r $<
-	ln -s /usr/lib/python2.7/dist-packages/PyQt4 $(VENV)/lib/python2.7/site-packages/
-	ln -s /usr/lib/python2.7/dist-packages/sip.*so $(VENV)/lib/python2.7/site-packages/


### PR DESCRIPTION
Add Makefile for easy virtualenv creation and app running

If `virtualenv` and `python-qt4` are installed on the system all you need to do is:

    make

And you'll have the gui running on the screen.

Since SIP and PyQt4 are difficult to install in a virtualenv, the virtualenv settings allow to use system-wide packages. This way we do not need to install SIP and PyQt4 inside the virtualenv.