### PR TITLE
Fix typo in word 'logged'

### DIFF
--- a/UI/login.py
+++ b/UI/login.py
@@ -61,7 +61,7 @@ class LoginUI(QtGui.QMainWindow):
             self.account_manager.save_account_credentials()
             msgBox = QtGui.QMessageBox(QtGui.QMessageBox.Information,
                                        'Success',
-                                       'Successfully loged in!',
+                                       'Successfully logged in!',
                                        QtGui.QMessageBox.Ok)
             result = msgBox.exec_()
             if result == QtGui.QMessageBox.Ok:


### PR DESCRIPTION
This fixes a typo where the word 'logged' in 'logged in' is spelled as 'loged'.